### PR TITLE
Allow trailing spaces in markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,7 @@ indent_size = 2
 # is also easier for line-based diffing tools to consume.
 # See: http://tex.stackexchange.com/questions/54140
 max_line_length = 80
+
+# Markdown uses trailing spaces to create line breaks.
+[*.md]
+trim_trailing_whitespace = false

--- a/app/templates/default.ini
+++ b/app/templates/default.ini
@@ -45,3 +45,7 @@ indent_size = 2
 # is also easier for line-based diffing tools to consume.
 # See: http://tex.stackexchange.com/questions/54140
 max_line_length = 80
+
+# Markdown uses trailing spaces to create line breaks.
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
to preserve formatting in `README` and other `.md` files
